### PR TITLE
Removed Min/Max from Short Answer Type

### DIFF
--- a/main/ui/public/src/questionTypes.mjs
+++ b/main/ui/public/src/questionTypes.mjs
@@ -207,7 +207,7 @@ const questionTypes = [
         label: "Short Answer",
         description: "User writes an answer in a scrollable text box.",
         hasRequired: true,
-        hasMinMax: true,
+        hasMinMax: false,
         hasChoices: false,
         minText: "Minimum required characters",
         maxText: "Maximum allowed characters",


### PR DESCRIPTION
Closes #72

## Description
Turns out, it was just a single value that needed to be changed to remove the minmax feature from the short answer.

## Related Issue
Closes #72

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor / Code cleanup
- [ ] Documentation update

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings or errors
- [X] I have added or updated tests where applicable
- [ ] PR has been reviewed by at least one teammate
