### PR TITLE
Fixed duplicate survey to create separate visualization ids

### DIFF
--- a/main/api/routes/surveyDesigns.js
+++ b/main/api/routes/surveyDesigns.js
@@ -16,6 +16,12 @@ const router = express.Router()
 const cookieParser = require('cookie-parser')
 router.use(cookieParser())
 
+// setup axios API interface for visualization engine
+const axios = require('axios')
+const visualApi = axios.create({
+  baseURL: process.env.VISUAL_API_URL
+})
+
 // Create new survey design
 router.post('/', requireAuthentication, handleErrors(async (req, res, next) => {
   // Get survey data from req
@@ -100,6 +106,22 @@ router.post('/:id/duplicate', requireAuthentication, handleErrors(async (req, re
   })
 
   for (const q of originalQuestions) {
+    let newVisualizationContentId = null
+
+    // If question has a visualization, create a copy of it
+    if (q.visualizationContentId) {
+      try {
+        // Fetch the original visualization SVG
+        const originalVisual = await visualApi.get(`/${q.visualizationContentId}`)
+        // Create a new visualization with the same SVG
+        const newVisual = await visualApi.post('/', { svg: originalVisual.data.svg })
+        newVisualizationContentId = newVisual.data.id
+      } catch (err) {
+        console.error('Failed to duplicate visualization:', err.message)
+        // Continue without visualization if copy fails
+      }
+    }
+
     await Question.create({
       surveyDesignId: newDesign.id,
       number: q.number,
@@ -113,7 +135,7 @@ router.post('/:id/duplicate', requireAuthentication, handleErrors(async (req, re
       choices: q.choices,
       disableZoom: q.disableZoom,
       disablePan: q.disablePan,
-      visualizationContentId: q.visualizationContentId
+      visualizationContentId: newVisualizationContentId
     })
   }
 


### PR DESCRIPTION
## Description
Visualizations now have separate ids when cloned. 

## Related Issue
Closes #220 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Refactor / Code cleanup
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [ ] I have added or updated tests where applicable
- [ ] PR has been reviewed by at least one teammate
